### PR TITLE
Changed to read .wav files; cleaned comments; removed extra imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ music-player
 
 A simple music player in python, includes what I think is a decent shuffle function.
 
-Version 1.0: (Currently supports only .mp3)
+Version 1.0: (Currently supports only .wav)
 
     -- Save your audio files in the working directory (doesn't matter if other files are present as well)
     -- Run the program
   
 Features:
 
-    -- Will read all the files and parse out the mp3s.
+    -- Will read all the files and parse out the wavs.
     
-    -- Will add all the mp3s to a list.
+    -- Will add all the wavss to a list.
     
     -- Will shuffle the list enough so there is an illusion of randomness.
     

--- a/player.py
+++ b/player.py
@@ -1,50 +1,29 @@
 import os
-from os import listdir
 import pyglet
 import random
-from pyglet import app
-from pyglet import window
 
-song_list=[]   ##empty list to store the list of songs
+# empty list to store the list of songs
+song_list = []
 
 for file in os.listdir("."):
-	if ".mp3" in file:
-		song_list.append(file)           ##listdir will list all files and even the subdirectories, so I just 
-										 ##used a workaround to add only the mp3 files
+    if ".wav" in file:
+        # listdir will list all files and subdirectories, so I just used a workaround to add only the .wav files
+        # EDIT: To use .mp3 files, you will have to use AVbin otherwise this error occurs...
+            # pyglet.media.riff.WAVEFormatException: AVbin is required to decode compressed media
+        song_list.append(file)
 
+# player object has the option of queueing
+player = pyglet.media.Player()
 
-player = pyglet.media.Player()           ##player object has the option of queueing
-
+# making the playlist random
 random.shuffle(song_list)
 random.shuffle(song_list)
 random.shuffle(song_list)               
-random.shuffle(song_list)   ##making the playlist random
+random.shuffle(song_list)
 
 for song in song_list:
-	
-	audio = pyglet.resource.media(song)
-	player.queue(audio)
-
-
+    audio = pyglet.resource.media(song)
+    player.queue(audio)
 
 player.play()
 pyglet.app.run()
-
-
-
-	
-
-
-
-
-
-	
-
-
-
-
-
-	
-	
-
-	


### PR DESCRIPTION
I forked your repository to see if I could use it for myself and found out that an error occurs when I run the program. I discovered that in order to play .mp3 files, you need AVbin installed. I installed it, but still did not work. My workaround was to have your file read .wav files as to bypass the error.

If you do not want the file to change, disregard this request. Make note however I will have the copy in my repositories.

Thank you.
